### PR TITLE
feat: delete 기능 추가/ RestAPI 컨트롤러 추가/ 커스텀 예외 및 전역 핸들러 추가/ 로깅 추가/ ResponseDto 추가

### DIFF
--- a/src/main/java/com/example/firstproject/api/ArticleApiController.java
+++ b/src/main/java/com/example/firstproject/api/ArticleApiController.java
@@ -1,0 +1,103 @@
+package com.example.firstproject.api;
+
+import com.example.firstproject.dto.ApiResponseDto;
+import com.example.firstproject.dto.ArticleRequestDto;
+import com.example.firstproject.entity.Article;
+import com.example.firstproject.exception.NotFoundException;
+import com.example.firstproject.repository.ArticleRepository;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.Response;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+
+/**
+ * 게시글 관련 Rest Api 컨트롤러 입니다.
+ * 뷰 템플릿이 아닌 JSON 데이터를 반환합니다.
+ * @RestController : 해당 어노테이션이 붙은 컨트롤러의 리턴값은 자동으로 JSON 변환 대상이 됩니다.
+ */
+@RestController
+@Slf4j
+public class ArticleApiController {
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    // GET
+    // 모든 게시글 조회
+    @GetMapping("/api/articles")
+    public ResponseEntity<ApiResponseDto<Iterable<Article>>> index() {
+
+        Iterable<Article> articleList = articleRepository.findAll();
+
+        return ResponseEntity.ok(
+                ApiResponseDto.of("Articles successfully retrieved", articleList)
+        );
+    }
+
+    // 단일 게시글 조회
+    @GetMapping("/api/articles/{id}")
+    public ResponseEntity<ApiResponseDto<Article>> show(@PathVariable Long id) {
+
+        Article article = articleRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Article", id));
+
+        return ResponseEntity.ok(
+                ApiResponseDto.of("Article successfully retrieved", article)
+        );
+    }
+
+
+    // POST
+    // 게시글 생성
+    @PostMapping("/api/articles")
+    public ResponseEntity<ApiResponseDto<Article>> create(@RequestBody ArticleRequestDto dto) {
+        Article article = dto.toEntity();
+        Article saved = articleRepository.save(article);
+
+        // URI는 헤더의 Location에 포함되어 응답된다.
+        // REST 규약 준수 : 생성된 리소스의 경로를 포함하는 것은 RestAPI 아키텍처 권장사항이다.
+        // 클라이언트 편의성 : 클라이언트 측에서 생성된 리소스를 즉시 조회할 수 있고 경로를 예상할 필요가 없다.
+        return ResponseEntity
+                .created(URI.create("/api/articles/" + saved.getId()))
+                .body(ApiResponseDto.of("Article successfully created", saved));
+    }
+
+    // PATCH
+    @PatchMapping("/api/articles/{id}")
+    @Transactional
+    public ResponseEntity<ApiResponseDto<Article>> update(
+            @PathVariable Long id,
+            @RequestBody ArticleRequestDto dto
+    ) {
+
+        Article target = articleRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Article", id)); // 커스텀 예외 적용
+        log.info("UPDATE 대상 데이터 : {}", target);
+
+        target.patch(dto);
+        log.info("UPDATE 결과 데이터 : {}", target);
+
+        return ResponseEntity.ok(
+                ApiResponseDto.of("Article successfully updated", target)
+        );
+    }
+
+    // DELETE
+    @DeleteMapping("/api/articles/{id}")
+    public ResponseEntity<ApiResponseDto> delete(@PathVariable Long id) {
+
+        Article target = articleRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Article", id));
+        log.info("DELETE 대상 데이터 : {}", target);
+
+        articleRepository.delete(target);
+
+        return ResponseEntity.ok()
+                .body(ApiResponseDto.of("Article successfully deleted", target));
+    }
+}

--- a/src/main/java/com/example/firstproject/api/CoffeeApiController.java
+++ b/src/main/java/com/example/firstproject/api/CoffeeApiController.java
@@ -1,0 +1,102 @@
+package com.example.firstproject.api;
+
+import com.example.firstproject.dto.ApiResponseDto;
+import com.example.firstproject.dto.CoffeeRequestDto;
+import com.example.firstproject.entity.Coffee;
+import com.example.firstproject.exception.NotFoundException;
+import com.example.firstproject.repository.CoffeeRepository;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@Slf4j
+public class CoffeeApiController {
+
+    @Autowired
+    private CoffeeRepository coffeeRepository;
+
+    /**
+     * 모든 커피 목록을 조회합니다.
+     */
+    @GetMapping("/api/coffees")
+    public ResponseEntity<ApiResponseDto<Iterable<Coffee>>> index() {
+
+        Iterable<Coffee> coffeeList = coffeeRepository.findAll();
+
+        return ResponseEntity.ok(
+                ApiResponseDto.of("Coffees successfully retrieved", coffeeList)
+        );
+    }
+
+    /**
+     * 단일 커피를 조회합니다.
+     */
+    @GetMapping("/api/coffees/{id}")
+    public ResponseEntity<ApiResponseDto<Coffee>> show(@PathVariable Long id) {
+
+        Coffee coffee = coffeeRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Coffee", id));
+
+        return ResponseEntity.ok(
+                ApiResponseDto.of("Coffee successfully retrieved", coffee)
+        );
+    }
+
+    /**
+     * 새로운 커피를 생성합니다.
+     */
+    @PostMapping("/api/coffees")
+    public ResponseEntity<ApiResponseDto<Coffee>> create(@RequestBody CoffeeRequestDto dto) {
+
+        Coffee coffee = dto.toEntity();
+        Coffee saved = coffeeRepository.save(coffee);
+
+        return ResponseEntity
+                .created(URI.create("/api/coffees/" + saved.getId()))
+                .body(ApiResponseDto.of("Coffee successfully created", saved));
+    }
+
+    /**
+     * 커피 정보를 수정합니다.
+     */
+    @PatchMapping("/api/coffees/{id}")
+    @Transactional
+    public ResponseEntity<ApiResponseDto<Coffee>> update(
+            @PathVariable Long id,
+            @RequestBody CoffeeRequestDto dto
+    ) {
+
+        Coffee target = coffeeRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Coffee", id));
+        log.info("수정 대상 데이터 : {}", target);
+
+        target.patch(dto);
+        log.info("수정 후 데이터 : {}", target);
+
+        return ResponseEntity.ok(
+                ApiResponseDto.of("Coffee successfully updated", target)
+        );
+    }
+
+    /**
+     * 커피 정보를 삭제합니다.
+     */
+    @DeleteMapping("/api/coffees/{id}")
+    public ResponseEntity<ApiResponseDto<Coffee>> delete(@PathVariable Long id) {
+
+        Coffee target = coffeeRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Coffee", id));
+        log.info("삭제 대상 데이터 : {}", target);
+
+        coffeeRepository.delete(target);
+
+        return ResponseEntity.ok(
+                ApiResponseDto.of("Coffee successfully deleted", target)
+        );
+    }
+}

--- a/src/main/java/com/example/firstproject/api/FirstApiController.java
+++ b/src/main/java/com/example/firstproject/api/FirstApiController.java
@@ -1,0 +1,17 @@
+package com.example.firstproject.api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * RestApi 설계를 따르는 첫번째 컨트롤러 입니다.
+ * @RestController : @Controller + @ResponseBody -> @ResponseBody는 뷰 템플릿이 아닌 데이터 자체를 반환하고 싶을 때 사용한다.
+ */
+@RestController
+public class FirstApiController {
+
+    @GetMapping("/api/hello")
+    public String hello() {
+        return "hello world!";
+    }
+}

--- a/src/main/java/com/example/firstproject/controller/ArticleController.java
+++ b/src/main/java/com/example/firstproject/controller/ArticleController.java
@@ -1,6 +1,6 @@
 package com.example.firstproject.controller;
 
-import com.example.firstproject.dto.ArticleForm;
+import com.example.firstproject.dto.ArticleRequestDto;
 import com.example.firstproject.entity.Article;
 import com.example.firstproject.repository.ArticleRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -13,9 +13,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
-
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**
@@ -81,7 +78,7 @@ public class ArticleController {
      */
     @PostMapping("/articles/update")
     @Transactional
-    public String update(ArticleForm form) {
+    public String update(ArticleRequestDto form) {
         log.info(form.toString());
 
         // 1. 기존 데이터 조회
@@ -140,7 +137,7 @@ public class ArticleController {
      * 게시글을 생성합니다.
      */
     @PostMapping("/articles/create")
-    public String createArticle(ArticleForm form) {
+    public String createArticle(ArticleRequestDto form) {
         log.info(form.toString());
 
         // 1. DTO를 엔티티로 변환

--- a/src/main/java/com/example/firstproject/controller/ArticleController.java
+++ b/src/main/java/com/example/firstproject/controller/ArticleController.java
@@ -12,6 +12,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -95,6 +96,35 @@ public class ArticleController {
 
         // 4. 수정 결과 페이지로 리다이렉트
         return "redirect:/articles/" + target.getId();
+    }
+
+    /**
+     * 게시글 삭제 api 입니다.
+     * HTML의 form은 delete 메소드를 제공하지 않으므로 GetMapping 사용
+     */
+    @GetMapping("/articles/{id}/delete")
+    @Transactional
+    public String delete(@PathVariable Long id, RedirectAttributes rttr) {
+
+        log.info("삭제 요청이 들어왔습니다!");
+
+        // 1. 삭제할 대상 가져오기
+        Article target = articleRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        String.format("삭제할 %d번 데이터를 찾을 수 없습니다", id)
+                ));
+        log.info("삭제 대상 데이터 : " + target.toString());
+
+        // 2. 대상 엔티티 삭제하기
+        articleRepository.delete(target);
+
+        // 리다이렉트 시점에 한 번만 사용할 데이터 등록
+        // Model을 상속받는 객체라서 뷰 템플릿에서 사용 가능함
+        rttr.addFlashAttribute("msg", String.format("%d번 글이 삭제되었습니다!", id));
+
+
+        // 3. 결과 페이지로 리다이렉트
+        return "redirect:/articles";
     }
 
 

--- a/src/main/java/com/example/firstproject/controller/MemberController.java
+++ b/src/main/java/com/example/firstproject/controller/MemberController.java
@@ -1,6 +1,6 @@
 package com.example.firstproject.controller;
 
-import com.example.firstproject.dto.MemberForm;
+import com.example.firstproject.dto.MemberRequestDto;
 import com.example.firstproject.entity.Member;
 import com.example.firstproject.repository.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -37,7 +37,7 @@ public class MemberController {
      * 회원 정보를 받아 DB에 저장합니다.
      */
     @PostMapping("/join")
-    public String newMember(MemberForm form) {
+    public String newMember(MemberRequestDto form) {
         // 0. 데이터를 DTO로 잘 받았는지 확인
         log.info(form.toString());
 
@@ -83,7 +83,7 @@ public class MemberController {
      */
     @PostMapping("/members/update")
     @Transactional
-    public String update(MemberForm form) {
+    public String update(MemberRequestDto form) {
 
         log.info("수정 요청 데이터 : " + form.toString());
 

--- a/src/main/java/com/example/firstproject/controller/MemberController.java
+++ b/src/main/java/com/example/firstproject/controller/MemberController.java
@@ -12,6 +12,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 /**
  * 회원가입 관련 컨트롤러 입니다.
@@ -94,6 +95,27 @@ public class MemberController {
         log.info("수정된 데이터 : " + target.toString());
 
         return "redirect:/members/" + target.getId();
+    }
+
+    /**
+     * 회원 정보 삭제 api 입니다.
+     */
+    @GetMapping("/members/{id}/delete")
+    @Transactional
+    public String delete(@PathVariable Long id, RedirectAttributes rttr) {
+
+        log.info(String.format("%d번 회원 삭제 요청이 들어왔습니다!", id));
+
+        Member target = memberRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        String.format("삭제할 %d번 회원이 존재하지 않습니다.", id)
+                ));
+        log.info("삭제 대상 회원 정보 : " + target.toString());
+
+        memberRepository.delete(target);
+        rttr.addFlashAttribute("msg", String.format("%d번 회원이 성공적으로 삭제되었습니다!", id));
+
+        return "redirect:/members";
     }
 
 

--- a/src/main/java/com/example/firstproject/dto/ApiResponseDto.java
+++ b/src/main/java/com/example/firstproject/dto/ApiResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.firstproject.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApiResponseDto<T> { // 제네릭 변수 T를 사용하겠다
+
+    private String message;
+    private T data;
+
+    // 데이터 없이 메시지만 보낼 경우 사용
+    public static <T> ApiResponseDto<T> of(String message) { // 자유로운 타입의 T 제네릭을 사용할 것이고 그 타입은 T(자유로운)이다
+        return new ApiResponseDto<>(message, null); // AllArgsConstructor에 의해 생성된 생성자 호출
+    }
+
+    // 데이터와 메시지 모두 보낼 경우 사용
+    public static <T> ApiResponseDto<T> of(String message, T data) {
+        return new ApiResponseDto<>(message, data);
+    }
+}

--- a/src/main/java/com/example/firstproject/dto/ArticleRequestDto.java
+++ b/src/main/java/com/example/firstproject/dto/ArticleRequestDto.java
@@ -11,7 +11,7 @@ import lombok.ToString;
 @AllArgsConstructor
 @Getter
 @ToString
-public class ArticleForm {
+public class ArticleRequestDto {
 
     private Long id; // id
     private String title; // 제목

--- a/src/main/java/com/example/firstproject/dto/CoffeeRequestDto.java
+++ b/src/main/java/com/example/firstproject/dto/CoffeeRequestDto.java
@@ -1,0 +1,20 @@
+package com.example.firstproject.dto;
+
+import com.example.firstproject.entity.Coffee;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Getter
+@ToString
+public class CoffeeRequestDto {
+
+    private Long id;
+    private String name;
+    private String price;
+
+    public Coffee toEntity() {
+        return new Coffee(name, price);
+    }
+}

--- a/src/main/java/com/example/firstproject/dto/MemberRequestDto.java
+++ b/src/main/java/com/example/firstproject/dto/MemberRequestDto.java
@@ -11,7 +11,7 @@ import lombok.ToString;
 @AllArgsConstructor
 @ToString
 @Getter
-public class MemberForm {
+public class MemberRequestDto {
 
     private Long id;
     private String email;

--- a/src/main/java/com/example/firstproject/entity/Article.java
+++ b/src/main/java/com/example/firstproject/entity/Article.java
@@ -1,10 +1,7 @@
 package com.example.firstproject.entity;
 
-import com.example.firstproject.dto.ArticleForm;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import com.example.firstproject.dto.ArticleRequestDto;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,7 +19,7 @@ import lombok.ToString;
 public class Article {
 
     @Id             // primary key
-    @GeneratedValue // autoincrement 어노테이션
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // autoincrement 어노테이션
     private Long id;
     @Column
     private String title;
@@ -35,7 +32,7 @@ public class Article {
     }
 
     // UPDATE 작업을 위한 엔티티 값 변경 (PATCH) 메서드
-    public void patch(ArticleForm form) {
+    public void patch(ArticleRequestDto form) {
         if (form.getTitle() != null) {
             this.title = form.getTitle();
         }

--- a/src/main/java/com/example/firstproject/entity/Coffee.java
+++ b/src/main/java/com/example/firstproject/entity/Coffee.java
@@ -1,0 +1,38 @@
+package com.example.firstproject.entity;
+
+import com.example.firstproject.dto.CoffeeRequestDto;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Getter
+public class Coffee {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column
+    private String name;
+    @Column
+    private String price;
+
+    public Coffee(String name, String price) {
+        this.name = name;
+        this.price = price;
+    }
+
+    public void patch(CoffeeRequestDto dto) {
+        if (dto.getName() != null) {
+            this.name = dto.getName();
+        }
+        if (dto.getPrice() != null) {
+            this.price = dto.getPrice();
+        }
+    }
+}

--- a/src/main/java/com/example/firstproject/entity/Member.java
+++ b/src/main/java/com/example/firstproject/entity/Member.java
@@ -1,6 +1,6 @@
 package com.example.firstproject.entity;
 
-import com.example.firstproject.dto.MemberForm;
+import com.example.firstproject.dto.MemberRequestDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -29,7 +29,7 @@ public class Member {
     @Column
     private String password;
 
-    public void patch(MemberForm form) {
+    public void patch(MemberRequestDto form) {
         if (form.getEmail() != null) {
             this.email = form.getEmail();
         }

--- a/src/main/java/com/example/firstproject/exception/BaseException.java
+++ b/src/main/java/com/example/firstproject/exception/BaseException.java
@@ -1,0 +1,21 @@
+package com.example.firstproject.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 커스텀 예외의 기본 틀이 되는 클래스
+ *
+ * abstract : 추상 클래스 -> 직접 객체를 생성할 수 없고 상속받기 위한 기본 틀 역할을 한다
+ * RuntimeException : Java의 기본 예외 클래스
+ */
+@Getter
+public abstract class BaseException extends RuntimeException {
+
+    private final HttpStatus status;
+
+    protected BaseException(String message, HttpStatus status) {
+        super(message); // 부모 클래스 생성자 호출, 예외 메시지 전달
+        this.status = status;
+    }
+}

--- a/src/main/java/com/example/firstproject/exception/NotFoundException.java
+++ b/src/main/java/com/example/firstproject/exception/NotFoundException.java
@@ -1,0 +1,21 @@
+package com.example.firstproject.exception;
+
+import com.example.firstproject.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+
+public class NotFoundException extends BaseException {
+
+    /**
+     * 404 Not Found
+     *
+     * @param resourceName 조회에 실패한 데이터 이름
+     * @param fieldValue 조회 기준이 된 컬럼
+     */
+    public NotFoundException(String resourceName, Object fieldValue) {
+        super(
+                String.format("%s not found with field value: %s", resourceName, fieldValue),
+                HttpStatus.NOT_FOUND
+        );
+    }
+}

--- a/src/main/java/com/example/firstproject/exception/dto/ErrorResponseDto.java
+++ b/src/main/java/com/example/firstproject/exception/dto/ErrorResponseDto.java
@@ -1,0 +1,30 @@
+package com.example.firstproject.exception.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+/**
+ * 에러 메시지 응답용 dto 입니다.
+ */
+@Getter
+@AllArgsConstructor
+public class ErrorResponseDto {
+    private final String message;
+    private final int status;
+    private final String code;
+    private final LocalDateTime timestamp;
+    private final String path;
+
+    public static ErrorResponseDto of(String message, HttpStatus status, String path) {
+        return new ErrorResponseDto(
+                message,
+                status.value(),
+                status.name(),
+                LocalDateTime.now(),
+                path
+        );
+    }
+}

--- a/src/main/java/com/example/firstproject/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/firstproject/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,77 @@
+package com.example.firstproject.exception.handler;
+
+import com.example.firstproject.exception.BaseException;
+import com.example.firstproject.exception.dto.ErrorResponseDto;
+import com.example.firstproject.service.log.ErrorLogService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 전역 예외 처리 핸들러 입니다.
+ *
+ * 특정 예외에 대하여 다음과 같은 동작을 수행합니다 :
+ * -> 로깅
+ * -> 상태코드 및 에러 응답 반환
+ */
+@Slf4j
+@RestControllerAdvice // @ControllerAdvice + @ResponseBody -> 응답을 자동으로 JSON 변환
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+    private final ErrorLogService errorLogService;
+
+    /**
+     * 모든 커스텀 예외를 처리합니다.
+     */
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ErrorResponseDto> handleBaseException(
+            BaseException e,
+            HttpServletRequest request
+    ) {
+        // 에러 로깅
+        errorLogService.logError(e, request);
+
+        // 에러 응답 생성
+        ErrorResponseDto response = ErrorResponseDto.of(
+                e.getMessage(),
+                e.getStatus(),
+                request.getRequestURI()
+        );
+
+        // 상태코드 및 에러 응답 반환
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(response);
+    }
+
+
+
+
+
+    /**
+     * 500 InternalServerError - 예상치 못한 모든 예외를 처리합니다.
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponseDto> handleUnexpectedException(
+            Exception e,
+            HttpServletRequest request
+    ) {
+
+        errorLogService.logError(e, request);
+
+        ErrorResponseDto response = ErrorResponseDto.of(
+                "Internal server error",
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                request.getRequestURI()
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(response);
+    }
+}

--- a/src/main/java/com/example/firstproject/repository/ArticleRepository.java
+++ b/src/main/java/com/example/firstproject/repository/ArticleRepository.java
@@ -4,7 +4,6 @@ package com.example.firstproject.repository;
 import com.example.firstproject.entity.Article;
 import org.springframework.data.repository.CrudRepository;
 
-import java.util.ArrayList;
 
 /**
  * Article 엔티티의 리파지터리 입니다.

--- a/src/main/java/com/example/firstproject/repository/CoffeeRepository.java
+++ b/src/main/java/com/example/firstproject/repository/CoffeeRepository.java
@@ -1,0 +1,7 @@
+package com.example.firstproject.repository;
+
+import com.example.firstproject.entity.Coffee;
+import org.springframework.data.repository.CrudRepository;
+
+public interface CoffeeRepository extends CrudRepository<Coffee, Long> {
+}

--- a/src/main/java/com/example/firstproject/service/log/ErrorLogService.java
+++ b/src/main/java/com/example/firstproject/service/log/ErrorLogService.java
@@ -1,0 +1,26 @@
+package com.example.firstproject.service.log;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 에러 로그를 출력하는 서비스입니다.
+ */
+@Slf4j
+@Service
+public class ErrorLogService {
+    public void logError(Exception e, HttpServletRequest request) {
+        log.error("Exception occurred: {} at URI: {}",
+                e.getMessage(),
+                request.getRequestURI(),
+                e // 예외 객체 자체를 전달하여 스택트레이스를 로그에 포함
+        );
+
+        /**
+         * TODO
+         * 추가적인 로깅 로직 작성
+         * ex) DB에 저장, 모니터링 시스템에 전송 등
+         */
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,19 @@ spring.h2.console.enabled=true
 
 # data.sql ??? ??? ??? ??? ??
 spring.jpa.defer-datasource-initialization=true
+
+# JPA logging settings
+# set debug Level for show query
+logging.level.org.hibernate.SQL=DEBUG
+
+# set show query CRLF
+spring.jpa.properties.hibernate.format_sql=true
+
+# set show bind parameter
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+
+# set not create H2 unique URL
+spring.datasource.generate-unique-name=false
+
+# set fixed H2 URL
+spring.datasource.url=jdbc:h2:mem:testdb

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,7 +1,11 @@
-INSERT INTO article(id, title, content) VALUES(1, '가가가가', '1111');
-INSERT INTO article(id, title, content) VALUES(2, '나나나나', '2222');
-INSERT INTO article(id, title, content) VALUES(3, '다다다다', '3333');
+INSERT INTO article(title, content) VALUES('가가가가', '1111');
+INSERT INTO article(title, content) VALUES('나나나나', '2222');
+INSERT INTO article(title, content) VALUES('다다다다', '3333');
 
 INSERT INTO member(id, email, password) VALUES(1, 'ysk9526@gmail.com', '1111');
 INSERT INTO member(id, email, password) VALUES(2, 'sss1122@gmail.com', '2222');
 INSERT INTO member(id, email, password) VALUES(3, 'fkdj5653@gmail.com', '3333');
+
+INSERT INTO coffee(name, price) VALUES('아메리카노', '4500');
+INSERT INTO coffee(name, price) VALUES('라떼', '5000');
+INSERT INTO coffee(name, price) VALUES('카페 모카', '5500');

--- a/src/main/resources/templates/articles/show.mustache
+++ b/src/main/resources/templates/articles/show.mustache
@@ -18,5 +18,6 @@
     </tbody>
 </table>
 <a href="/articles/{{article.id}}/edit" class="btn btn-primary">Edit</a>
+<a href="/articles/{{article.id}}/delete" class="btn btn-danger">Delete</a>
 <a href="/articles">Go to Article List</a>
 {{>layouts/footer}}

--- a/src/main/resources/templates/layouts/header.mustache
+++ b/src/main/resources/templates/layouts/header.mustache
@@ -48,3 +48,10 @@
         </div>
     </div>
 </nav>
+
+{{#msg}}
+<div class="alert alert-primary alert-dismissible">
+    {{msg}}
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>
+{{/msg}}

--- a/src/main/resources/templates/members/show.mustache
+++ b/src/main/resources/templates/members/show.mustache
@@ -18,5 +18,6 @@
     </tbody>
 </table>
 <a href="/members/{{member.id}}/edit" class="btn btn-primary">수정하기</a>
+<a href="/members/{{member.id}}/delete" class="btn btn-danger">삭제하기</a>
 <a href="/members">Go to member list</a>
 {{>layouts/footer}}


### PR DESCRIPTION
게시글/회원 삭제 기능 구현
- form에서 DELETE 메서드 사용 불가로 컨트롤러 GetMapping으로 요청 받음
- 리포지토리 delete() 메서드로 데이터 삭제
- RedirectAttributes 객체로 리다이렉트 페이지에서 삭제 완료 메시지 출력

Rest API
- RestController 추가
- 커스텀 예외 추가
- 예외 전역 핸들러 추가
- 로깅 서비스 추가
- ResponseDto 추가
- 모든 Rest Controller에 대하여 일관적인 응답/예외가 리턴되도록 구현
