### PR TITLE
feat: 댓글 엔티티, 리파지터리 구현, QueryDSL 공통 인터페이스 및 커스텀 리파지터리 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,10 +23,34 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-mustache'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// Querydsl 의존성
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+	// Querydsl 의존성
+
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'org.assertj:assertj-core:3.21.0'
+}
+
+// Querydsl 설정
+def querydslDir = layout.buildDirectory.dir('generated/querydsl').get().asFile
+querydslDir.mkdirs()
+
+sourceSets {
+	main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(querydslDir)
+}
+
+clean {
+	delete querydslDir
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/firstproject/api/ArticleApiController.java
+++ b/src/main/java/com/example/firstproject/api/ArticleApiController.java
@@ -24,8 +24,11 @@ import java.util.List;
 @ResponseStatus(HttpStatus.OK)
 public class ArticleApiController {
 
-    @Autowired
-    private ArticleService articleService;
+    private final ArticleService articleService;
+
+    public ArticleApiController(ArticleService articleService) {
+        this.articleService = articleService;
+    }
 
     // 모든 게시글 조회
     @GetMapping("/api/articles")

--- a/src/main/java/com/example/firstproject/api/CoffeeApiController.java
+++ b/src/main/java/com/example/firstproject/api/CoffeeApiController.java
@@ -16,13 +16,16 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URI;
 import java.util.List;
 
-@Slf4j
-@ResponseStatus(HttpStatus.OK)
 @RestController
+@ResponseStatus(HttpStatus.OK)
+@Slf4j
 public class CoffeeApiController {
 
-    @Autowired
-    private CoffeeService coffeeService;
+    private final CoffeeService coffeeService;
+
+    public CoffeeApiController(CoffeeService coffeeService) {
+        this.coffeeService = coffeeService;
+    }
 
     /**
      * 모든 커피 목록을 조회합니다.

--- a/src/main/java/com/example/firstproject/config/QuerydslConfig.java
+++ b/src/main/java/com/example/firstproject/config/QuerydslConfig.java
@@ -1,0 +1,33 @@
+package com.example.firstproject.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Querydsl 설정 클래스 입니다.
+ *
+ * EntityManager : JPA의 핵심 클래스, 엔티티 관리와 DB작업 담당
+ * JPAQueryFactory : Querydsl 쿼리를 생성하는 핵심 클래스
+ *
+ * EntityManager를 주입받아(@PersistenceContext),
+ * JPAQueryFactory를 빈으로 등록해두면(@Bean),
+ * 다른 클래스들에서 @Autowired로 JPAQueryFactory를 주입받아 QueryDSL을 사용할 수 있다
+ * 또는, 생성자 호출 시 자동 주입되도록 할 수도 있다
+ */
+@Configuration // 스프링의 설정 클래스임을 나타내는 어노테이션
+public class QuerydslConfig {
+
+    @PersistenceContext // JPA의 EntityManager를 주입받기 위한 표준 어노테이션이다.
+    private EntityManager entityManager;
+
+    // JPAQueryFactory 빈을 생성하여 스프링 컨테이너에 등록한다.
+    // 이 빈은 다른 컴포넌트(빈)에서 QueryDSL을 사용할 때 주입받아 사용 가능하다.
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/example/firstproject/controller/ArticleController.java
+++ b/src/main/java/com/example/firstproject/controller/ArticleController.java
@@ -18,8 +18,8 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 /**
  * 게시글 관련 컨트롤러 입니다.
  */
-@Slf4j
 @Controller
+@Slf4j
 public class ArticleController {
 
     @Autowired

--- a/src/main/java/com/example/firstproject/controller/MemberController.java
+++ b/src/main/java/com/example/firstproject/controller/MemberController.java
@@ -17,8 +17,8 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 /**
  * 회원가입 관련 컨트롤러 입니다.
  */
-@Slf4j
 @Controller
+@Slf4j
 public class MemberController {
 
     @Autowired

--- a/src/main/java/com/example/firstproject/entity/Article.java
+++ b/src/main/java/com/example/firstproject/entity/Article.java
@@ -11,10 +11,10 @@ import lombok.ToString;
  * 엔티티 클래스입니다.
  * DB의 테이블과 연결됩니다.
  */
+@Entity
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
-@Entity
 @Getter
 public class Article {
 

--- a/src/main/java/com/example/firstproject/entity/Comment.java
+++ b/src/main/java/com/example/firstproject/entity/Comment.java
@@ -1,0 +1,33 @@
+package com.example.firstproject.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * Article(게시글)과 연동되는 댓글 엔티티 클래스 입니다.
+ */
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Getter
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne // 참조 대상 테이블과 다대일 관계 설정
+    @JoinColumn(name="article_id") // 외래키 설정
+    private Article article; // 부모 게시글
+
+    @Column
+    private String nickname;
+
+    @Column
+    private String body;
+
+}

--- a/src/main/java/com/example/firstproject/entity/Member.java
+++ b/src/main/java/com/example/firstproject/entity/Member.java
@@ -14,11 +14,11 @@ import lombok.ToString;
  * 엔티티 클래스입니다.
  * Member 테이블과 연결됩니다.
  */
+@Entity
 @AllArgsConstructor
 @NoArgsConstructor
-@Getter
 @ToString
-@Entity
+@Getter
 public class Member {
 
     @Id

--- a/src/main/java/com/example/firstproject/repository/CommentRepository.java
+++ b/src/main/java/com/example/firstproject/repository/CommentRepository.java
@@ -1,0 +1,26 @@
+package com.example.firstproject.repository;
+
+import com.example.firstproject.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+/**
+ * Article(게시글)과 연동되는 댓글 리파지터리 입니다.
+ *
+ * JPA는 구현체가 아닌 인터페이스를 상속받아도, Impl에 실제 구현된 메서드를 사용할 수 있다.
+ * Impl을 붙임으로써, JPA는 커스텀 구현체 클래스를 찾는다.
+ */
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
+
+    // 특정 게시글의 모든 댓글 조회
+    @Query(
+            value = "SELECT * FROM comment WHERE article_id = :articleId",
+            nativeQuery = true
+    )
+    List<Comment> findByArticleId(Long articleId);
+
+    // 특정 닉네임의 모든 댓글 조회
+    List<Comment> findByNickname(String nickname);
+}

--- a/src/main/java/com/example/firstproject/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/example/firstproject/repository/CommentRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.example.firstproject.repository;
+
+import com.example.firstproject.entity.Comment;
+
+import java.util.List;
+
+/**
+ * 댓글 커스텀 리포지토리 구현을 위한 인터페이스 입니다.
+ * Querydsl4RepositorySupport과 함께 상속받아 Querydsl을 사용할 수 있습니다.
+ */
+public interface CommentRepositoryCustom {
+    List<Comment> search(String nickname, String body);
+    List<Comment> findByBody(String body);
+}

--- a/src/main/java/com/example/firstproject/repository/CommentRepositoryCustomImpl.java
+++ b/src/main/java/com/example/firstproject/repository/CommentRepositoryCustomImpl.java
@@ -1,0 +1,78 @@
+package com.example.firstproject.repository;
+
+import com.example.firstproject.entity.Comment;
+import com.example.firstproject.repository.support.Querydsl4RepositorySupport;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+import static com.example.firstproject.entity.QComment.comment;
+
+/**
+ * 댓글 커스텀 리포지토리 구현체입니다.
+ */
+@Repository
+public class CommentRepositoryCustomImpl extends Querydsl4RepositorySupport implements CommentRepositoryCustom{
+
+    /**
+     * QuerydslConfig에서 JPAQueryFactory를 스프링 컨테이너에 빈으로써 등록해 두었다.
+     * 스프링은 컨테이너에서 객체를 찾아, 생성자의 인자로 자동으로 전달한다.
+     *
+     * 이 클래스는 @Repository 어노테이션이 달려 있기 때문에 자동으로 빈으로 등록되고 인식되는 것이다.
+     *
+     */
+
+    /**
+     * 실제 리파지터리(CommentRepository)에서 Impl을 상속받고 사용할 때,
+     * 이 생성자가 자동으로 호출되며 JPAQueryFactory에 대한 의존성 주입이 일어난다.
+     */
+    public CommentRepositoryCustomImpl(JPAQueryFactory queryFactory) {
+        super(queryFactory, Comment.class);
+    }
+
+    /**
+     * nickname, body를 포함하는 레코드를 모두 찾습니다. ( LIKE )
+     */
+    @Override
+    public List<Comment> search(String nickname, String body) {
+        return getQueryFactory()
+                .selectFrom(comment)
+                .where(
+                        nicknameContains(nickname),
+                        bodyContains(body)
+                )
+                .fetch();
+    }
+
+    /**
+     * body가 일치하는 레코드를 모두 찾습니다.
+     */
+    @Override
+    public List<Comment> findByBody(String body) {
+        return getQueryFactory()
+                .selectFrom(comment)
+                .where(
+                        comment.body.eq(body)
+                )
+                .fetch();
+    }
+
+    /**
+     * QueryDSL은 where절에 null이 들어올 경우 조건을 무시합니다.
+     *
+     * nickname 또는 body 값이 null일 경우,
+     * 해당 조건을 제외하는 동적 쿼리 작성을 가능하게 합니다.
+     */
+    private BooleanExpression nicknameContains(String nickname) {
+        return StringUtils.hasText(nickname) ? comment.nickname.contains(nickname) : null;
+    }
+
+    private BooleanExpression bodyContains(String body) {
+        return StringUtils.hasText(body) ? comment.body.contains(body) : null;
+    }
+
+}

--- a/src/main/java/com/example/firstproject/repository/support/Querydsl4RepositorySupport.java
+++ b/src/main/java/com/example/firstproject/repository/support/Querydsl4RepositorySupport.java
@@ -1,0 +1,30 @@
+package com.example.firstproject.repository.support;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 모든 QueryDSL 리포지터리 공통 기능을 제공하는 베이스 클래스 입니다.
+ *
+ * domainClass : 어떤 엔티티를 다루는지 타입 정보를 받는다
+ *
+ * @Repository
+ * - 스프링의 컴포넌트 스캔 대상이 된다(자동으로 빈으로 등록)
+ * - 데이터 액세스 계층의 빈임을 명시
+ * - 트랜잭션 처리가 필요한 빈임을 명시
+ * - JPA 예외를 스프링의 DataAccessException으로 변환
+ */
+@Repository
+public abstract class Querydsl4RepositorySupport {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Querydsl4RepositorySupport(JPAQueryFactory queryFactory, Class<?> domainClass) {
+        this.queryFactory = queryFactory;
+    }
+
+    protected JPAQueryFactory getQueryFactory() {
+        return queryFactory;
+    }
+}

--- a/src/main/java/com/example/firstproject/service/ArticleService.java
+++ b/src/main/java/com/example/firstproject/service/ArticleService.java
@@ -7,7 +7,6 @@ import com.example.firstproject.exception.NotFoundException;
 import com.example.firstproject.repository.ArticleRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -22,8 +21,12 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true) // 읽기 전용 기본값 설정
 public class ArticleService {
 
-    @Autowired
-    private ArticleRepository articleRepository;
+    private final ArticleRepository articleRepository;
+
+    public ArticleService(ArticleRepository articleRepository) {
+        this.articleRepository = articleRepository;
+    }
+
 
     /**
      * 모든 게시글을 조회합니다.

--- a/src/main/java/com/example/firstproject/service/CoffeeService.java
+++ b/src/main/java/com/example/firstproject/service/CoffeeService.java
@@ -20,8 +20,11 @@ import java.util.List;
 @Service
 public class CoffeeService {
 
-    @Autowired
-    private CoffeeRepository coffeeRepository;
+    private final CoffeeRepository coffeeRepository;
+
+    public CoffeeService(CoffeeRepository coffeeRepository) {
+        this.coffeeRepository = coffeeRepository;
+    }
 
     /**
      * 모든 커피 목록을 조회합니다.

--- a/src/main/java/com/example/firstproject/service/log/ErrorLogService.java
+++ b/src/main/java/com/example/firstproject/service/log/ErrorLogService.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Service;
 /**
  * 에러 로그를 출력하는 서비스입니다.
  */
-@Slf4j
 @Service
+@Slf4j
 public class ErrorLogService {
     public void logError(Exception e, HttpServletRequest request) {
         log.error("Exception occurred: {} at URI: {}",

--- a/src/main/resources/META-INF/orm.xml
+++ b/src/main/resources/META-INF/orm.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<entity-mappings xmlns="https://jakarta.ee/xml/ns/persistence/orm"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence/orm
+                 https://jakarta.ee/xml/ns/persistence/orm/orm_3_0.xsd"
+                 version="3.0">
+    <named-native-query
+            name="Comment.findByNickname"
+            result-class="com.example.firstproject.entity.Comment">
+        <query>
+            <![CDATA[
+                    SELECT * FROM comment WHERE nickname = :nickname
+            ]]>
+        </query>
+    </named-native-query>
+</entity-mappings>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,6 @@ spring.datasource.generate-unique-name=false
 
 # set fixed H2 URL
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_ON_EXIT=FALSE
+
+# always running data.sql
+spring.sql.init.mode=always

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,11 +1,31 @@
+-- 게시글 데이터 입력
 INSERT INTO article(title, content) VALUES('가가가가', '1111');
 INSERT INTO article(title, content) VALUES('나나나나', '2222');
 INSERT INTO article(title, content) VALUES('다다다다', '3333');
 
+INSERT INTO article(title, content) VALUES('당신의 인생 영화는?', '댓글 고');
+INSERT INTO article(title, content) VALUES('당신의 소울 푸드는?', '댓글 고고');
+INSERT INTO article(title, content) VALUES('당신의 취미는?', '댓글 고고고');
+
+-- 댓글 데이터 입력
+INSERT INTO comment(article_id, nickname, body) VALUES(4, 'Park', '굿 윌 헌팅');
+INSERT INTO comment(article_id, nickname, body) VALUES(4, 'Kim', '아이 엠 샘');
+INSERT INTO comment(article_id, nickname, body) VALUES(4, 'Choi', '쇼생크 탈출');
+
+INSERT INTO comment(article_id, nickname, body) VALUES(5, 'Park', '치킨');
+INSERT INTO comment(article_id, nickname, body) VALUES(5, 'Kim', '샤브샤브');
+INSERT INTO comment(article_id, nickname, body) VALUES(5, 'Choi', '초밥');
+
+INSERT INTO comment(article_id, nickname, body) VALUES(6, 'Park', '조깅');
+INSERT INTO comment(article_id, nickname, body) VALUES(6, 'Kim', '유튜브 시청');
+INSERT INTO comment(article_id, nickname, body) VALUES(6, 'Choi', '독서');
+
+-- 회원 데이터 입력
 INSERT INTO member(id, email, password) VALUES(1, 'ysk9526@gmail.com', '1111');
 INSERT INTO member(id, email, password) VALUES(2, 'sss1122@gmail.com', '2222');
 INSERT INTO member(id, email, password) VALUES(3, 'fkdj5653@gmail.com', '3333');
 
+-- 커피 데이터 입력
 INSERT INTO coffee(name, price) VALUES('아메리카노', '4500');
 INSERT INTO coffee(name, price) VALUES('라떼', '5000');
 INSERT INTO coffee(name, price) VALUES('카페 모카', '5500');

--- a/src/test/java/com/example/firstproject/repository/CommentRepositoryCustomTest.java
+++ b/src/test/java/com/example/firstproject/repository/CommentRepositoryCustomTest.java
@@ -1,0 +1,61 @@
+package com.example.firstproject.repository;
+
+import com.example.firstproject.config.QuerydslConfig;
+import com.example.firstproject.entity.Article;
+import com.example.firstproject.entity.Comment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(QuerydslConfig.class)
+class CommentRepositoryCustomTest {
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    @Test
+    @DisplayName("nickname, body를 모두 포함하는(LIKE) 모든 댓글을 성공적으로 조회합니다.")
+    void searchCommentsByNicknameAndBodySuccess() {
+
+        // given
+        String nickname = "Choi";
+        String body = "크";
+        Article article = new Article(4L, "당신의 인생 영화는?", "댓글 고");
+        Comment comment = new Comment(3L, article, "Choi", "쇼생크 탈출");
+        List<Comment> expected = List.of(comment);
+
+        // when
+        List<Comment> comments = commentRepository.search(nickname, body);
+
+        // then
+        assertThat(comments)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Body 데이터가 일치하는 모든 댓글을 성공적으로 조회합니다.")
+    void findCommentsByBodySuccess() {
+
+        // given
+        String body = "초밥";
+        Article article = new Article(5L, "당신의 소울 푸드는?", "댓글 고고");
+        Comment comment = new Comment(6L, article, "Choi", "초밥");
+        List<Comment> expected = List.of(comment);
+
+        // when
+        List<Comment> comments = commentRepository.findByBody(body);
+
+        // then
+        assertThat(comments)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+}

--- a/src/test/java/com/example/firstproject/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/example/firstproject/repository/CommentRepositoryTest.java
@@ -1,0 +1,63 @@
+package com.example.firstproject.repository;
+
+import com.example.firstproject.config.QuerydslConfig;
+import com.example.firstproject.entity.Article;
+import com.example.firstproject.entity.Comment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest // 리파지터리 테스트용 어노테이션
+@Import(QuerydslConfig.class)
+class CommentRepositoryTest {
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    @Test
+    @DisplayName("특정 게시글의 모든 댓글을 성공적으로 조회합니다.")
+    void findByArticleIdSuccess() {
+
+        // given
+        Long articleId = 4L;
+        Article article = new Article(4L, "당신의 인생 영화는?", "댓글 고");
+        Comment a = new Comment(1L, article, "Park", "굿 윌 헌팅");
+        Comment b = new Comment(2L, article, "Kim", "아이 엠 샘");
+        Comment c = new Comment(3L, article, "Choi", "쇼생크 탈출");
+        List<Comment> expected = List.of(a, b, c);
+
+        // when
+        List<Comment> comments = commentRepository.findByArticleId(articleId);
+
+        // then
+        assertThat(comments)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("특정 사용자가 작성한 모든 댓글을 성공적으로 조회합니다.")
+    void findByNicknameSuccess() {
+
+        // given
+        String nickname = "Park";
+        Comment a = new Comment(1L, new Article(4L, "당신의 인생 영화는?", "댓글 고"), nickname, "굿 윌 헌팅");
+        Comment b = new Comment(4L, new Article(5L, "당신의 소울 푸드는?", "댓글 고고"), nickname, "치킨");
+        Comment c = new Comment(7L, new Article(6L, "당신의 취미는?", "댓글 고고고"), nickname, "조깅");
+        List<Comment> expected = List.of(a, b, c);
+
+        // when
+        List<Comment> comments = commentRepository.findByNickname(nickname);
+
+        // then
+        assertThat(comments)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+}

--- a/src/test/java/com/example/firstproject/service/ArticleServiceTest.java
+++ b/src/test/java/com/example/firstproject/service/ArticleServiceTest.java
@@ -4,6 +4,7 @@ import com.example.firstproject.dto.ArticleRequestDto;
 import com.example.firstproject.entity.Article;
 import com.example.firstproject.exception.NotFoundException;
 import com.example.firstproject.repository.ArticleRepository;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -32,13 +33,17 @@ class ArticleServiceTest {
     ArticleRepository articleRepository;
 
     @Test
-    void index_모든_게시글을_성공적으로_조회한다() {
+    @DisplayName("모든 게시글을 성공적으로 조회합니다.")
+    void showArticlesSuccess() {
 
         // given
         Article a = new Article(1L, "가가가가", "1111");
         Article b = new Article(2L, "나나나나", "2222");
         Article c = new Article(3L, "다다다다", "3333");
-        List<Article> expected = List.of(a, b, c);
+        Article d = new Article(4L, "당신의 인생 영화는?", "댓글 고");
+        Article e = new Article(5L, "당신의 소울 푸드는?", "댓글 고고");
+        Article f = new Article(6L, "당신의 취미는?", "댓글 고고고");
+        List<Article> expected = List.of(a, b, c, d, e, f);
 
         // when
         List<Article> articles = articleService.index();
@@ -50,7 +55,8 @@ class ArticleServiceTest {
     }
 
     @Test
-    void show_단일_게시글을_성공적으로_조회한다() {
+    @DisplayName("단일 게시글을 성공적으로 조회합니다.")
+    void showArticleSuccess() {
 
         // given
         Long id = 1L;
@@ -66,12 +72,13 @@ class ArticleServiceTest {
     }
 
     @Test
-    void create_단일_게시글을_성공적으로_생성한다() {
+    @DisplayName("단일 게시글을 성공적으로 생성합니다.")
+    void createArticleSuccess() {
 
         // given
         String title = "라라라라";
         String content = "4444";
-        Article expected = new Article(4L, title, content);
+        Article expected = new Article(7L, title, content);
         ArticleRequestDto dto = new ArticleRequestDto(null, title, content);
 
         // when
@@ -85,7 +92,8 @@ class ArticleServiceTest {
 
 
     @Test
-    void update_단일_게시글을_성공적으로_수정한다() {
+    @DisplayName("단일 게시글을 성공적으로 수정합니다.")
+    void updateArticleSuccess() {
 
         // given
         Long id = 1L;
@@ -105,7 +113,8 @@ class ArticleServiceTest {
     }
 
     @Test
-    void delete_단일_게시글을_성공적으로_삭제한다() {
+    @DisplayName("단일 게시글을 성공적으로 삭제합니다.")
+    void deleteArticleSuccess() {
 
         // given
         Long id = 1L;
@@ -122,7 +131,8 @@ class ArticleServiceTest {
     }
 
     @Test
-    void delete_존재하지_않는_게시글_삭제시도하면_404_예외발생() {
+    @DisplayName("존재하지 않는 게시글을 삭제 시도하면 404 예외가 발생합니다.")
+    void deleteArticleThrowsNotFoundException() {
 
         // given
         Long nonExistentId = -1L;


### PR DESCRIPTION
댓글 엔티티, 리파지터리 구현, 의존성 주입 방식 변경
엔티티 :
- Article(게시글) 테이블과 다대일 관계 설정 및 외래키 설정

리파지터리 :
- @Query 및 XML을 사용한 native query 작성
- QueryDSL 사용을 위한 추상 클래스 및 커스텀 리파지터리 추가 구현
- applicaion.properties, build.gradle 설정
- QueryDSL 로직을 각 리파지터리에서 재사용할 수 있도록 추상 베이스 클래스 작성
- 커스텀 리파지터리 인터페이스 및 구현체 작성
- 기존 리파지터리에서 커스텀 리파지터리 인터페이스를 상속받아 QueryDSL 사용
- 리파지터리/커스텀 리파지터리 테스트 코드 작성

의존성 주입 방식 변경 : @Autowired -> 생성자 주입 방식