### PR TITLE
feat: 댓글 RestApi 컨트롤러, 서비스 구현(조회, 생성)/ 댓글 dto, dto<->객체 변환 메서드, 스트림 문…

### DIFF
--- a/src/main/java/com/example/firstproject/api/CommentApiController.java
+++ b/src/main/java/com/example/firstproject/api/CommentApiController.java
@@ -1,0 +1,66 @@
+package com.example.firstproject.api;
+
+import com.example.firstproject.constant.CommentResponseMessage;
+import com.example.firstproject.dto.ApiResponseDto;
+import com.example.firstproject.dto.CommentDto;
+import com.example.firstproject.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@ResponseStatus(HttpStatus.OK)
+@RequiredArgsConstructor
+public class CommentApiController {
+
+    private final CommentService commentService;
+
+    /**
+     * 특정 게시글의 모든 댓글을 조회합니다.
+     */
+    @GetMapping("/api/articles/{articleId}/comments")
+    public ApiResponseDto<List<CommentDto>> getArticleComments(@PathVariable Long articleId) {
+
+        List<CommentDto> comments = commentService.findCommentsByArticleId(articleId);
+
+        return ApiResponseDto.of(CommentResponseMessage.COMMENTS_RETRIEVED, comments);
+    }
+
+
+    /**
+     * 특정 게시글의 댓글을 생성합니다.
+     */
+    @PostMapping("/api/articles/{articleId}/comments")
+    public ResponseEntity<ApiResponseDto<CommentDto>> createArticleComment(
+            @PathVariable Long articleId,
+            @RequestBody CommentDto dto
+    ) {
+        // 게시글 생성
+        CommentDto created = commentService.saveArticleComment(articleId, dto);
+
+        // 응답 형태로 변환 및 리턴
+        ApiResponseDto<CommentDto> response = ApiResponseDto.of(
+                CommentResponseMessage.COMMENT_CREATED,
+                created
+        );
+        return ResponseEntity.created(URI.create("/api/articles/" + articleId + "/comments"))
+                .body(response);
+    }
+
+
+
+    /**
+     * 댓글을 수정합니다.
+     */
+
+
+    /**
+     * 댓글을 삭제합니다.
+     */
+
+
+}

--- a/src/main/java/com/example/firstproject/constant/CommentResponseMessage.java
+++ b/src/main/java/com/example/firstproject/constant/CommentResponseMessage.java
@@ -1,0 +1,12 @@
+package com.example.firstproject.constant;
+
+/**
+ * 댓글 관련 응답 메시지를 관리하는 클래스입니다.
+ */
+public class CommentResponseMessage {
+    public static final String COMMENTS_RETRIEVED = "Comments successfully retrieved";
+    public static final String COMMENT_RETRIEVED = "Comment successfully retrieved";
+    public static final String COMMENT_CREATED = "Comment successfully created";
+    public static final String COMMENT_UPDATED = "Comment successfully updated";
+    public static final String COMMENT_DELETED = "Comment successfully deleted";
+}

--- a/src/main/java/com/example/firstproject/dto/CommentDto.java
+++ b/src/main/java/com/example/firstproject/dto/CommentDto.java
@@ -1,0 +1,44 @@
+package com.example.firstproject.dto;
+
+import com.example.firstproject.entity.Article;
+import com.example.firstproject.entity.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 댓글 응답용 dto 입니다.
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentDto {
+    private Long id;
+    private Long articleId;
+    private String nickname;
+    private String body;
+
+    /**
+     * Comment 객체를 dto 형태로 변환합니다.
+     */
+    public static CommentDto from(Comment comment) {
+        return new CommentDto(
+                comment.getId(),
+                comment.getArticle().getId(),
+                comment.getNickname(),
+                comment.getBody()
+        );
+    }
+
+    /**
+     * dto를 Comment 객체로 변환합니다.
+     */
+    public static Comment toEntity(Article article, CommentDto dto) {
+        return new Comment(
+                null, // id는 엔티티에서 자동 부여된다.
+                article,
+                dto.getNickname(),
+                dto.getBody()
+        );
+    }
+}

--- a/src/main/java/com/example/firstproject/service/CommentService.java
+++ b/src/main/java/com/example/firstproject/service/CommentService.java
@@ -1,0 +1,61 @@
+package com.example.firstproject.service;
+
+import com.example.firstproject.dto.CommentDto;
+import com.example.firstproject.entity.Article;
+import com.example.firstproject.entity.Comment;
+import com.example.firstproject.exception.NotFoundException;
+import com.example.firstproject.repository.ArticleRepository;
+import com.example.firstproject.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final ArticleRepository articleRepository;
+
+    /**
+     * 특정 게시글의 모든 댓글을 조회합니다.
+     */
+    public List<CommentDto> findCommentsByArticleId(Long id) {
+
+        List<Comment> comments = commentRepository.findByArticleId(id);
+
+        return comments.stream()
+                .map(CommentDto::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 특정 게시글의 댓글을 생성합니다.
+     */
+    @Transactional
+    public CommentDto saveArticleComment(Long articleId, CommentDto dto) {
+
+        // 부모 게시글 찾기
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new NotFoundException("Article", articleId));
+
+        // dto를 엔티티로 변환
+        Comment commentEntity = dto.toEntity(article, dto);
+
+        // db에 저장
+        Comment saved = commentRepository.save(commentEntity);
+
+        // 저장한 거 dto로 다시 변환
+        CommentDto savedDto = CommentDto.from(saved);
+
+        // 리턴
+        return savedDto;
+    }
+
+}


### PR DESCRIPTION
…법 사용

댓글 RestApi 컨트롤러, 서비스 구현
- 댓글 dto 작성
- 댓글 dto -> 객체 / 객체 -> dto 변환 메서드 작성
- 서비스 함수 스트림 문법 사용

의존성 주입 방식 변경 : 생성자 직접 구현 -> @RequiredArgsConstructor 어노테이션 으로 변경

엔티티 -> dto 변환 / dto -> 엔티티 변환 메서드는 "dto 클래스" 에 작성하는 것이 적절.
엔티티는 dto를 알 필요가 없지만, dto는 엔티티를 알아야 한다.